### PR TITLE
Rasbperry install with one single command line (instead of 3)

### DIFF
--- a/installation/de_DE/raspberrypi.asciidoc
+++ b/installation/de_DE/raspberrypi.asciidoc
@@ -71,11 +71,7 @@ Si vous choisissez d'ouvrir votre port 22 sur l'extérieur, vous devez impérati
 
 
 ----
-wget https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh
-
-chmod +x install.sh
-
-sudo ./install.sh
+wget -O- https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh | sudo bash
 ----
 *Le mot de passe sudo est également raspberry*
 

--- a/installation/en_US/raspberrypi.asciidoc
+++ b/installation/en_US/raspberrypi.asciidoc
@@ -71,11 +71,7 @@ Si vous choisissez d'ouvrir votre port 22 sur l'extérieur, vous devez impérati
 
 
 ----
-wget https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh
-
-chmod +x install.sh
-
-sudo ./install.sh
+wget -O- https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh | sudo bash
 ----
 *Le mot de passe sudo est également raspberry*
 

--- a/installation/es_ES/raspberrypi.asciidoc
+++ b/installation/es_ES/raspberrypi.asciidoc
@@ -71,11 +71,7 @@ Si vous choisissez d'ouvrir votre port 22 sur l'extérieur, vous devez impérati
 
 
 ----
-wget https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh
-
-chmod +x install.sh
-
-sudo ./install.sh
+wget -O- https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh | sudo bash
 ----
 *Le mot de passe sudo est également raspberry*
 

--- a/installation/fr_FR/raspberrypi.asciidoc
+++ b/installation/fr_FR/raspberrypi.asciidoc
@@ -71,11 +71,7 @@ Si vous choisissez d'ouvrir votre port 22 sur l'extérieur, vous devez impérati
 
 
 ----
-wget https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh
-
-chmod +x install.sh
-
-sudo ./install.sh
+wget -O- https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh | sudo bash
 ----
 *Le mot de passe sudo est également raspberry*
 

--- a/installation/id_ID/raspberrypi.asciidoc
+++ b/installation/id_ID/raspberrypi.asciidoc
@@ -71,11 +71,7 @@ Si vous choisissez d'ouvrir votre port 22 sur l'extérieur, vous devez impérati
 
 
 ----
-wget https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh
-
-chmod +x install.sh
-
-sudo ./install.sh
+wget -O- https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh | sudo bash
 ----
 *Le mot de passe sudo est également raspberry*
 

--- a/installation/it_IT/raspberrypi.asciidoc
+++ b/installation/it_IT/raspberrypi.asciidoc
@@ -71,11 +71,7 @@ Si vous choisissez d'ouvrir votre port 22 sur l'extérieur, vous devez impérati
 
 
 ----
-wget https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh
-
-chmod +x install.sh
-
-sudo ./install.sh
+wget -O- https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh | sudo bash
 ----
 *Le mot de passe sudo est également raspberry*
 

--- a/installation/ru_RU/raspberrypi.asciidoc
+++ b/installation/ru_RU/raspberrypi.asciidoc
@@ -71,11 +71,7 @@ Si vous choisissez d'ouvrir votre port 22 sur l'extérieur, vous devez impérati
 
 
 ----
-wget https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh
-
-chmod +x install.sh
-
-sudo ./install.sh
+wget -O- https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh | sudo bash
 ----
 *Le mot de passe sudo est également raspberry*
 


### PR DESCRIPTION
Instead of downloading the script, then change permission, and finally
run the script, it's possible to run the install script by running
only one command line.
Moreover, with this method, the script file will not be kept locally
(which is OK since once the script has been executed, we don't need it
anymore).