### PR TITLE
Update sauvegarde.comment_faire.asciidoc

### DIFF
--- a/howto/fr_FR/sauvegarde.comment_faire.asciidoc
+++ b/howto/fr_FR/sauvegarde.comment_faire.asciidoc
@@ -1,19 +1,14 @@
-= Sauvegarde - Comment faire ?
+= Sauvegardes - Comment faire ?
 
 == Description
 
 Il y a deux manières de sauvegarder Jeedom et chacune comporte des avantages et des inconvénients.
 
-Il est possible de réaliser une sauvegarde à partir de l'interface Jeedom, cette sauvegarde concerne uniquement 
-le logiciel Jeedom et ses données. Elle a l'avantage de pouvoir être faite à chaud et 
-le fichier de sauvegarde peut être exporté vers d'autres supports.
+Il est possible de réaliser une sauvegarde à partir de l'interface Jeedom. Celle-ci concerne uniquement le logiciel Jeedom et ses données. Elle a l'avantage de pouvoir être faite à chaud et le fichier de sauvegarde peut être exporté vers d'autres supports.
 
-Il est aussi possible de réaliser une sauvegarde en faisant une image disque de la carte microSD (mini et mini+). 
-Elle a l'avantage d'être une sauvegarde complète du système ainsi que de Jeedom et ses données. 
-Par contre il faut l'effectuer en éteignant Jeedom et en branchant la carte microSD sur un autre ordinateur.
+Il est aussi possible de réaliser une sauvegarde en faisant une image disque de la carte microSD (mini et mini+). Cette façon a l'avantage d'être une sauvegarde complète du système ainsi que de Jeedom et ses données. Par contre il faut l'effectuer en éteignant Jeedom et en branchant la carte microSD sur un autre ordinateur.
 
-Le meilleur moyen d'être tranquille est d'utiliser les deux : 
-Faire une sauvegarde de la carte microSD de temps en temps et programmer une sauvegarde régulière de Jeedom.
+Le meilleur moyen d'être tranquille est d'utiliser les deux : Faire une sauvegarde de la carte microSD de temps en temps et programmer une sauvegarde régulière de Jeedom.
 
 [TIP]
 La procédure de restauration de la carte microSD peut-être utile pour restaurer un Jeedom par défaut à partir de l'image 
@@ -22,78 +17,7 @@ fournie par l'équipe voir https://www.jeedom.fr/doc/documentation/installation/
 
 == Sauvegarde/Restauration de Jeedom
 
-Afin de gérer et paramétrer les sauvegardes, il faut se rendre dans le menu _Général > Administration > Sauvegardes_.
-
-=== Configurations
-
-. [underline]#Paramètres Généraux#
-
-* Fréquence des sauvegardes ° : Permet de définir la fréquence à laquelle Jeedom va automatiquement lancer une sauvegarde de lui-même. Exemple : `00 02 * * *` : Lance une sauvegarde tous les jours à 02h00 du matin.
-* Sauvegardes : Le bouton _Lancer_ permet de lancer manuellement une sauvegarde de Jeedom.
-* Emplacement des sauvegardes ° : Permet de modifier le répertoire de destination des fichiers de sauvegarde. (Par défaut : `backup`) Le chemin est relatif par rapport à l'arborescence de Jeedom (`/usr/share/nginx/www/jeedom/`)
-* Nombre de jour(s) de conservation des sauvegardes ° : Permet de définir le temps de rétention des fichiers de sauvegarde. Les fichiers de sauvegarde plus vieux que ce paramètre seront automatiquement supprimés.
-* Taille totale maximum d'une sauvegarde (Mo) ° : Permet de limiter la taille du fichier de sauvegarde. Si la sauvegarde créée un fichier plus gros que cette taille, elle se met en erreur et vous prévient par une alerte.
-* Envoyer les sauvegardes dans le cloud : Une fois cette case cochée, les sauvegardes seront automatiquement envoyées sur les serveurs cloud de Jeedom. Attention : Cette option nécessite l'achat d'un abonnement à partir de votre profil du market.
-
-Ne pas oublier de cliquer sur le bouton vert _Sauvegarder_ afin d'enregistrer les changements de configuration.
-
-_Remarque: Les paramètres suivis d'un ° sont uniquement disponibles en mode expert._
-
-image::../images/save-restore02.jpg[align="center"]
-
-
-[TIP]
-Afin que Jeedom fasse automatiquement une sauvegarde avant les mises à jour, 
-il y a une case à cocher (_"Faire une sauvegarde avant la mise à jour"_) dans la section _"Market et mise à jour"_ du menu _Général > Administration > Configuration_.
-
-. [underline]#Sauvegardes locales#
-
-* Sauvegardes disponibles : Permet de voir et sélectionner le fichier de sauvegarde locale qui sera utilisé pour les actions sur les boutons suivants.
-* Restaurer la sauvegarde : Le bouton _Restaurer_ permet de lancer une restauration de Jeedom en utilisant le fichier de sauvegarde sélectionné dans la liste _Sauvegardes disponibles_.
-* Supprimer la sauvegarde : Le bouton _Supprimer_ permet de supprimer le fichier de sauvegarde sélectionné dans la liste _Sauvegardes disponibles_.
-* Télécharger la sauvegarde : Le bouton _Télécharger_ permet de récupérer sur son ordinateur le fichier de sauvegarde sélectionné dans la liste _Sauvegardes disponibles_.
-* Envoyer une sauvegarde : Permet de réinjecter dans Jeedom un fichier de sauvegarde que vous auriez téléchargé sur votre ordinateur, afin de pouvoir l'utiliser pour restaurer Jeedom.
-+
-image::../images/save-restore03.jpg[align="center"]
-
-. [underline]#Sauvegardes cloud#
-
-* Sauvegardes disponibles : Permet de voir et sélectionner le fichier de sauvegarde disponible sur le cloud qui sera utilisé pour la restauration.
-* Restaurer la sauvegarde : Le bouton _Restaurer_ permet de lancer une restauration de Jeedom en utilisant le fichier de sauvegarde sélectionné dans la liste _Sauvegardes disponibles_.
-+
-image::../images/save-restore04.jpg[align="center"]
-
-[IMPORTANT]
-Afin de pouvoir utiliser la sauvegarde sur le cloud vous devez acheter un abonnement à partir de votre profil sur le market Jeedom. Vous pouvez aussi à cet endroit voir et récupérer les fichiers de sauvegarde disponible.
-
-image::../images/save-restore05.jpg[align="center"]
-
-=== Sauvegarde
-
-On a vu que l'on peut configurer Jeedom afin qu'il se sauvegarde automatiquement à intervalle régulier 
-mais aussi avant de lancer des mises à jour. Afin de lancer une sauvegarde manuellement se rendre dans 
-le menu _Général > Administration > Sauvegardes_, cliquer sur le bouton gris _Lancer_, 
-et attendre que Jeedom vous annonce par un bandeau vert que la sauvegarde s'est bien terminée. 
-Un log, sur la droite de la page, vous permet de suivre l'avancement.
-
-Une fois la sauvegarde terminée, vous pouvez récupérer le fichier sur votre ordinateur. 
-Si vous avez acheté un abonnement sauvegarde cloud, le fichier sera automatiquement 
-envoyé sur les serveurs cloud de Jeedom. Vous pouvez aussi utiliser le plugin Data Transfert afin 
-de copier ces fichiers sur un serveur FTP, SFTP, Dropbox...
-
-=== Restauration
-
-La restauration est aussi simple que la sauvegarde.
-
-Pour une restauration à partir d'une sauvegarde présente, sélectionner le fichier de sauvegarde correspondant 
-à la date voulue dans la liste _Sauvegardes disponibles_ (Sauvegardes locales ou Sauvegardes cloud), 
-puis cliquer sur _Restaurer_, et attendre que Jeedom vous annonce par un bandeau vert 
-que la restauration s'est bien terminée. Un log, sur la droite de la page, vous permet de suivre l'avancement.
-
-Si vous venez de réinstaller complètement votre mini+ (Par exemple à partir d'une image microSD vierge), 
-avant de lancer une restauration vous devez au préalable envoyer un fichier de sauvegarde de votre 
-ordinateur vers Jeedom en utilisant la fonction _Envoyer une sauvegarde_ de la section _Sauvegardes locales_.
-
+Une documentation est déjà présente pour expliquer la page Administration->Sauvegardes. Vous la trouverez https://github.com/jeedom/documentation/blob/master/howto/fr_FR/sauvegarde.comment_faire.asciidoc[ici].
 
 == Sauvegarde/Restauration de la carte microSD
 
@@ -117,23 +41,15 @@ image::../images/save-restore08.jpg[align="center"]
 
 Il faudra commencer par télécharger un logiciel tiers par exemple : http://sourceforge.net/projects/win32diskimager/[Win32 Disk Imager]
 
-. [underline]#Sauvegarde#
- 
-Lancer le logiciel et vérifier que la lettre en dessous de _Device_ corresponde bien à celle de votre carte/lecteur de carte.
-
-Dans le champ _Image File_, indiquer le nom du fichier image que vous voulez créer ainsi que l'endroit où il sera enregistré.
-
-Enfin cliquer sur le bouton _Read_, afin de créer l'image.
-
+. *Sauvegarde*
+* Lancez le logiciel et vérifiez que la lettre en dessous de _Device_ corresponde bien à celle de votre carte/lecteur de carte.
+* Dans le champ _Image File_, indiquez le nom du fichier image que vous voulez créer ainsi que l'endroit où il sera enregistré.
+* Enfin cliquez sur le bouton _Read_, afin de créer l'image.
 image::../images/save-restore09.jpg[align="center"]
-
-. Restauration
-
-Lancer le logiciel et vérifier que la lettre en dessous de _Device_ corresponde bien à celle de votre carte/lecteur de carte.
-
-Dans le champ _Image File_, allez chercher le fichier image que vous voulez restaurer.
-
-Enfin cliquer sur le bouton _Write_, afin de restaurer cette image sur la carte microSD.
+. *Restauration*
+* Lancez le logiciel et vérifiez que la lettre en dessous de _Device_ corresponde bien à celle de votre carte/lecteur de carte.
+* Dans le champ _Image File_, allez chercher le fichier image que vous voulez restaurer.
+* Enfin cliquez sur le bouton _Write_, afin de restaurer cette image sur la carte microSD.
 
 image::../images/save-restore10.jpg[align="center"]
 
@@ -143,47 +59,35 @@ Pour vous faciliter la tâche, vous pouvez télécharger le logiciel http://www.
 
 image::../images/save-restore11.jpg[align="center"]
 
-. [underline]#Sauvegarde#
-* Avec ApplePi-Baker : Sélectionner la bonne carte dans la liste _Pi-Crust_, et cliquer sur _Create Backup_ afin de créer un fichier image de votre carte microSD.
+. *Sauvegarde*
+* Avec ApplePi-Baker : Sélectionnez la bonne carte dans la liste _Pi-Crust_, et cliquez sur _Create Backup_ afin de créer un fichier image de votre carte microSD.
 * En commande shell :
-** Afin de trouver le disque correspondant à la carte, ouvrir un terminal et saisir la commande : _diskutil list_
+** Afin de trouver le disque correspondant à la carte, ouvrez un terminal et saisissez la commande : `diskutil list`
 image::../images/save-restore12.jpg[align="center"]
-** Lancer la création de l'image en saisissant la commande : _sudo dd if=/dev/rdisk1 of=~/Desktop/Backup_Jeedom.img bs=1m_
-
-_Remarque: Dans cet exemple, le nom du disque de la carte est /dev/disk1, il faut donc saisir dans la commande de sauvegarde /dev/+++<u>r</u>+++disk1_
-
-. [underline]#Restauration#
-    
-* Avec ApplePi-Baker : Sélectionner la bonne carte dans la liste _Pi-Crust_, mettre le chemin vers le fichier image 
-à restaurer dans le champ _IMG file_ de la section _Pi-Ingredients_, et cliquer sur _Restore Backup_ afin de 
+** Lancez la création de l'image en saisissant la commande : `sudo dd if=/dev/disk1 of=~/Desktop/Backup_Jeedom.img bs=1m`
+_Remarque: Dans cet exemple, le nom du disque de la carte est `/dev/disk1`, il faut donc saisir dans la commande de sauvegarde `/dev/disk1`_
+. *Restauration*
+* Avec ApplePi-Baker : Sélectionnez la bonne carte dans la liste _Pi-Crust_, mettez le chemin vers le fichier image 
+à restaurer dans le champ _IMG file_ de la section _Pi-Ingredients_, et cliquez sur _Restore Backup_ afin de 
 restaurer l'image sur la carte microSD.
-
 * En commande shell :
-** Afin de trouver le disque correspondant à la carte, ouvrir un terminal et saisir la même commande que pour la sauvegarde : _diskutil list_ 
-** Démonter les partitions de la carte en tapant la commande : _sudo diskutil unmountDisk /dev/disk1_
-** Restaurer l'image sur la carte microsd en tapant la commande : _sudo dd bs=1m if=~/Desktop/Backup_Jeedom.img of=/dev/rdisk1_
-
-_Remarque: Dans cet exemple, le nom du disque de la carte est /dev/disk1, il faut donc saisir dans la commande de sauvegarde /dev/+++<u>r</u>+++disk1_
+** Afin de trouver le disque correspondant à la carte, ouvrez un terminal et saisissez la même commande que pour la sauvegarde : `diskutil list`
+** Démontez les partitions de la carte en tapant la commande : `sudo diskutil unmountDisk /dev/disk1`
+** Restaurez l'image sur la carte microSD en tapant la commande : `sudo dd bs=1m if=~/Desktop/Backup_Jeedom.img of=/dev/disk1`
+_Remarque : Dans cet exemple, le nom du disque de la carte est `/dev/disk1`, il faut donc saisir dans la commande de sauvegarde `/dev/disk1`_
 
 === Sous Linux
-
-. [underline]#Sauvegarde#   
-* Afin de trouver le disque correspondant à la carte, ouvrir un terminal et saisir la commande : _sudo fdisk -l | grep Dis_
-
+. *Sauvegarde*
+* Afin de trouver le disque correspondant à la carte, ouvrez un terminal et saisissez la commande : `sudo fdisk -l | grep Dis`
 [source,bash]
 $ sudo fdisk -l | grep Dis
 Disk /dev/sda: 320.1 GB, 320072933376 bytes
 Disk /dev/sdb: 16.0 GB, 16012804096 bytes
 Disk /dev/sdc: 8.0 GB, 8006402048 bytes
-
-* Lancer la création de l'image en saisissant la commande : _sudo dd if=/dev/sdc of=Backup_Jeedom.img bs=1m_
-
+* Lancez la création de l'image en saisissant la commande : `sudo dd if=/dev/sdc of=Backup_Jeedom.img bs=1m`
 _Remarque: Dans cet exemple, le nom du disque de la carte est /dev/sdc._
-
-. [underline]#Restauration#
-    
-* Afin de trouver le disque correspondant à la carte, ouvrir un terminal et saisir la commande : _sudo fdisk -l | grep Dis_+
-* Démonter les partitions de la carte en tapant la commande : _sudo umount /dev/sdc?*_
-* Restaurer l'image sur la carte microsd en tapant la commande : _sudo dd if=Backup_Jeedom.img of=/dev/sdc bs=1m_
-
+. *Restauration*
+* Afin de trouver le disque correspondant à la carte, ouvrez un terminal et saisissez la commande : `sudo fdisk -l | grep Dis`
+* Démontez les partitions de la carte en tapant la commande (en remplaçant le X par les numéros des partitions) : `sudo umount /dev/sdcX`
+* Restaurez l'image sur la carte microSD en tapant la commande : `sudo dd if=Backup_Jeedom.img of=/dev/sdc bs=1m`
 _Remarque: Dans cet exemple, le nom du disque de la carte est /dev/sdc._


### PR DESCRIPTION
Partie sauvegarde par l'interface Jeedom obsolète et redondante avec la page de la doc du core. J'ai préféré supprimé.
Par ailleurs, petit doute dans la partie "avec iOS", où il mettait rdisk1 au lieu de disk1... je pense que le r était en trop, n'est-ce pas ?