### PR TITLE
Update debian.trucs_et_astuces.md

### DIFF
--- a/howtoadvance/fr_FR/debian.trucs_et_astuces.md
+++ b/howtoadvance/fr_FR/debian.trucs_et_astuces.md
@@ -212,3 +212,9 @@ Suppression des librairies non nécessaires
 
     apt -y remove `aptitude -F %p search '~o' | grep -E -v ^lib`
     apt -y remove `aptitude -F %p search '~o'`----
+
+Note : Si lorsque vous ouvrez votre page Jeedom vous obtenez un code php, activez-le en lançant les commandes suivantes :
+
+    a2enmod php7.0 
+    systemctl restart apache2.service
+


### PR DESCRIPTION
Bonjour Loic

In some situations php7 need to be active after the distribution upgrade, so if the customer goes to jeedom web site a php code would be showed, if it's not activated. This fix the probelm

   a2enmod php7.0 
   systemctl restart apache2.service

This is my first contribution directly to the project in github, I hope that I did all steps right.

Merci
Bull